### PR TITLE
Use `rewrite` + `handle_path` for trailing slash and prefixes

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,9 +1,9 @@
 {$SERVER_NAME}
 
-# Handle requests for /ohttp-relay (with and without trailing slash)
-handle /ohttp-relay* {
-	uri strip_prefix /ohttp-relay
+# Handle requests without trailing slash
+rewrite /ohttp-relay /ohttp-relay/
 
+handle_path /ohttp-relay/* {
 	reverse_proxy {$OHTTP_GATEWAY} {
 		header_up -*
 	}


### PR DESCRIPTION
See:
- https://caddyserver.com/docs/caddyfile/patterns#trailing-slashes
- https://caddyserver.com/docs/caddyfile/directives/handle_path