### PR TITLE
Try parse gateway_origin as Uri

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ version = "0.0.1"
 dependencies = [
  "futures",
  "hex-conservative",
+ "http",
  "http-body-util",
  "hyper",
  "hyper-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ ws-bootstrap = ["futures", "hyper-tungstenite", "rustls", "tokio-tungstenite"]
 
 [dependencies]
 futures = { version = "0.3", optional = true }
+http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["http1", "server"] }
 hyper-rustls = { version = "0.26", features = ["webpki-roots"] }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use http::Uri;
 use http_body_util::combinators::BoxBody;
 use hyper::body::{Bytes, Incoming};
 use hyper::{Request, Response};
@@ -14,7 +15,7 @@ pub mod ws;
 
 pub(crate) async fn handle_ohttp_keys(
     mut req: Request<Incoming>,
-    gateway_origin: Arc<String>,
+    gateway_origin: Arc<Uri>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error> {
     #[cfg(feature = "connect-bootstrap")]
     if connect::is_connect_request(&req) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ pub(crate) enum Error {
     UnsupportedMediaType,
     BadRequest(String),
     NotFound,
+    #[allow(clippy::enum_variant_names)]
+    InternalServerError,
 }
 
 impl Error {
@@ -26,6 +28,7 @@ impl Error {
                 *res.body_mut() = full(e.to_string()).boxed();
             }
             Self::NotFound => *res.status_mut() = StatusCode::NOT_FOUND,
+            Self::InternalServerError => *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR,
         };
 
         res
@@ -40,6 +43,7 @@ impl std::fmt::Display for Error {
             Self::MethodNotAllowed => write!(f, "Method not allowed"),
             Self::BadRequest(e) => write!(f, "Bad request: {}", e),
             Self::NotFound => write!(f, "Not found"),
+            Self::InternalServerError => write!(f, "Internal server error"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,14 @@
+use std::str::FromStr;
+
+use http::Uri;
 use ohttp_relay::DEFAULT_PORT;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let port_env = std::env::var("PORT");
     let unix_socket_env = std::env::var("UNIX_SOCKET");
-    let gateway_origin = std::env::var("GATEWAY_ORIGIN").expect("GATEWAY_ORIGIN is required");
+    let gateway_origin_str = std::env::var("GATEWAY_ORIGIN").expect("GATEWAY_ORIGIN is required");
+    let gateway_origin = Uri::from_str(&gateway_origin_str).expect("Invalid GATEWAY_ORIGIN URI");
 
     match (port_env, unix_socket_env) {
         (Ok(_), Ok(_)) => panic!(


### PR DESCRIPTION
... in order to parse SocketAddr out of it more reliably.

Before, passing GATEWAY_ORIGIN="https://payjo.in" would not assign a port and might fail on bootstrap mechanisms. The internal function signatures used strings where more precise types helps for maintenance, too.