### PR TITLE
Fix nixos test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "ohttp-relay"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "futures",
  "hex-conservative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ohttp-relay"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "Relay Oblivious HTTP requests to protect IP metadata"
 repository = "https://github.com/payjoin/ohttp-relay"

--- a/src/bootstrap/connect.rs
+++ b/src/bootstrap/connect.rs
@@ -65,11 +65,11 @@ mod test {
 
     use super::*;
 
-    static GATEWAY_ORIGIN: Lazy<Uri> = Lazy::new(|| Uri::from_static("https://gateway.com"));
+    static GATEWAY_ORIGIN: Lazy<Uri> = Lazy::new(|| Uri::from_static("https://0.0.0.0:8080"));
 
     #[test]
     fn mismatched_gateways_not_allowed() {
-        let not_gateway_origin = "https://not-gateway.com";
+        let not_gateway_origin = "https://0.0.0.0:8081";
         let req = hyper::Request::builder().uri(not_gateway_origin).body(()).unwrap();
         let allowable_gateway = find_allowable_gateway(&req, &*GATEWAY_ORIGIN);
         assert!(allowable_gateway.is_none());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub async fn listen_tcp(
     port: u16,
     gateway_origin: Uri,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = TcpListener::bind(addr).await?;
     println!("OHTTP relay listening on tcp://{}", addr);
     ohttp_relay(listener, gateway_origin).await


### PR DESCRIPTION
DNS lookup happens when a socket address is created. I was using "gateway.com" and "not-gateway.com" as an examples in tests. I'm not finding DNS records for the second so that may have failed during a build.

For good measure I'm also making the loopback bindings 0.0.0.0 which fixed some platform compatibility problems elsewhere earlier.