### PR TITLE
Normalize GATEWAY_ORIGIN with GatewayUri type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "ohttp-relay"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "futures",
  "hex-conservative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ohttp-relay"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Dan Gould <d@ngould.dev>"]
 description = "Relay Oblivious HTTP requests to protect IP metadata"
 repository = "https://github.com/payjoin/ohttp-relay"

--- a/flake.nix
+++ b/flake.nix
@@ -62,11 +62,9 @@
           ];
 
           shellHook = ''
-            # Setup the Rust Nightly toolchain with rustup
             rustup default nightly
-
-            # Optionally, you can also include components like rust-src for Rust Analyzer
             rustup component add rust-src
+            export PATH=${pkgs.rustup}/bin:$PATH
           '';
         };
       });

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use http::Uri;
 use http_body_util::combinators::BoxBody;
 use hyper::body::{Bytes, Incoming};
 use hyper::{Request, Response};
 
 use crate::error::Error;
+use crate::GatewayUri;
 
 #[cfg(feature = "connect-bootstrap")]
 pub mod connect;
@@ -15,7 +15,7 @@ pub mod ws;
 
 pub(crate) async fn handle_ohttp_keys(
     mut req: Request<Incoming>,
-    gateway_origin: Arc<Uri>,
+    gateway_origin: Arc<GatewayUri>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error> {
     #[cfg(feature = "connect-bootstrap")]
     if connect::is_connect_request(&req) {

--- a/src/bootstrap/ws.rs
+++ b/src/bootstrap/ws.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::{Sink, SinkExt, StreamExt};
-use http::Uri;
 use http_body_util::combinators::BoxBody;
 use http_body_util::BodyExt;
 use hyper::body::{Bytes, Incoming};
@@ -16,6 +15,7 @@ use tokio_tungstenite::tungstenite::protocol::Message;
 use tokio_tungstenite::{tungstenite, WebSocketStream};
 
 use crate::error::Error;
+use crate::gateway_uri::GatewayUri;
 use crate::uri_to_addr;
 
 pub(crate) fn is_websocket_request(req: &Request<Incoming>) -> bool {
@@ -24,7 +24,7 @@ pub(crate) fn is_websocket_request(req: &Request<Incoming>) -> bool {
 
 pub(crate) async fn try_upgrade(
     req: &mut Request<Incoming>,
-    gateway_origin: Arc<Uri>,
+    gateway_origin: Arc<GatewayUri>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Error> {
     let (res, websocket) = hyper_tungstenite::upgrade(req, None)
         .map_err(|e| Error::BadRequest(format!("Error upgrading to websocket: {}", e)))?;

--- a/src/gateway_uri.rs
+++ b/src/gateway_uri.rs
@@ -1,0 +1,44 @@
+use http::Uri;
+
+/// A normalized gateway origin URI with a default port if none is specified.
+pub struct GatewayUri(Uri);
+
+impl GatewayUri {
+    pub fn new(mut gateway_origin: Uri) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let (scheme, default_port) = match gateway_origin.scheme_str() {
+            Some("http") => ("http", 80),
+            Some("https") | None => ("https", 443),
+            _ => return Err("Unsupported URI scheme".into()),
+        };
+
+        if gateway_origin.authority().map(|a| a.port().is_none()).unwrap_or(true) {
+            let authority = if let Some(auth) = gateway_origin.authority() {
+                format!("{}:{}", auth.host(), default_port)
+            } else {
+                return Err("URI must have an authority".into());
+            };
+
+            let path_and_query = gateway_origin
+                .path_and_query()
+                .map(|pq| pq.to_string())
+                .unwrap_or_else(|| "/".to_string());
+
+            let builder =
+                Uri::builder().scheme(scheme).authority(authority).path_and_query(path_and_query);
+
+            gateway_origin = builder.build()?;
+        }
+
+        Ok(Self(gateway_origin))
+    }
+}
+
+impl std::ops::Deref for GatewayUri {
+    type Target = Uri;
+
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl From<GatewayUri> for Uri {
+    fn from(val: GatewayUri) -> Self { val.0 }
+}


### PR DESCRIPTION

http::Uri does not enforce a port. GatewayUri does. Passing GATEWAY_ORIGIN without a port would otherwise succeed for some operations and fail when proxying others as, for example, a request uri authority and gateway origin could mismatch when one has a port and the other does not.