### PR TITLE
Add listen_tcp_on_free_port to return a test port

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default = ["bootstrap"]
 bootstrap = ["connect-bootstrap", "ws-bootstrap"]
 connect-bootstrap = []
 ws-bootstrap = ["futures", "hyper-tungstenite", "rustls", "tokio-tungstenite"]
+_test-util = []
 
 [dependencies]
 futures = { version = "0.3", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,8 @@ use hyper::{Response, StatusCode};
 
 use crate::{empty, full};
 
+pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
 #[derive(Debug)]
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum Error {

--- a/src/gateway_uri.rs
+++ b/src/gateway_uri.rs
@@ -1,11 +1,12 @@
 use http::Uri;
 
+use crate::error::BoxError;
 /// A normalized gateway origin URI with a default port if none is specified.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GatewayUri(Uri);
 
 impl GatewayUri {
-    pub fn new(mut gateway_origin: Uri) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    pub fn new(mut gateway_origin: Uri) -> Result<Self, BoxError> {
         let (scheme, default_port) = match gateway_origin.scheme_str() {
             Some("http") => ("http", 80),
             Some("https") | None => ("https", 443),

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
         (Err(_), Err(_)) => ohttp_relay::listen_tcp(DEFAULT_PORT, gateway_origin).await?,
     }
-
-    Ok(())
+    .await?
 }
 
 fn init_tracing() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -454,6 +454,15 @@ mod integration {
             .spawn()
             .expect("Failed to start nginx");
 
+        let start = std::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(5);
+        while start.elapsed() < timeout {
+            if let Ok(_) = std::net::TcpStream::connect(format!("127.0.0.1:{}", n_https_port)) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
         // Keep the config file open as long as NGINX is using it
         std::mem::forget(config_file);
 


### PR DESCRIPTION
Previously in tests downstream ohttp_relay was initiated with a port
that may no longer be free by the time it got bound. By having this
code bind on and return the port the indirection is removed.

I also found that the way I was having NGINX listen on a free port may also have led to the same problem, so the 3rd commit ensures NGINX is bound before the ohttp_relay tries to get a free port.