### PR TITLE
Implement RFC 9540

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,8 @@ fn into_forward_req(
         }
     }
 
-    *req.uri_mut() = gateway_origin.to_uri();
+    *req.uri_mut() = gateway_origin.rfc_9540_url();
+
     Ok(req)
 }
 


### PR DESCRIPTION
Note: This is a breaking change, and requires directory support for RFC 9540 as well.

This change modifies the relay to assume that both the the OHTTP gateway
and the ohttp keys reside at /.well-known/ohttp-gateway, with POST
requests implementing the OHTTP gateway functionality and GET requests
fetching the OHTTP keys.

Extends #46, but does not strictly depend on it.

Depends on #57