### PR TITLE
Dockerfile improvements and automatic Github Actions Docker builds

### DIFF
--- a/.github/workflows/build-image-on-push.yml
+++ b/.github/workflows/build-image-on-push.yml
@@ -1,0 +1,60 @@
+name: "Test build of image when Dockerfile is changed"
+
+on:
+  push:
+    paths:
+    - 'Dockerfile'
+    branches-ignore:
+    - main
+  pull_request:
+    paths:
+    - 'Dockerfile'
+  workflow_dispatch:
+
+env:
+  GHCR_REPO: ghcr.io/${{ github.repository_owner }}/ohttp-relay
+
+jobs:
+  rebuild-container:
+    name: "Build image with cache"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Prepare platform matrix for arm64
+        if: runner.arch == 'ARM64'
+        run: |
+          echo "PLATFORM=linux/arm64" >> $GITHUB_ENV
+          echo "DIGEST_NAME=arm64" >> $GITHUB_ENV
+      - name: Prepare platform matrix for amd64
+        if: runner.arch == 'X64'
+        run: |
+          echo "PLATFORM=linux/amd64" >> $GITHUB_ENV
+          echo "DIGEST_NAME=amd64" >> $GITHUB_ENV
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.9.0
+      -
+        name: Checkout repository
+        uses: actions/checkout@v4
+      -
+        name: Test build of image
+        id: build
+        uses: docker/build-push-action@v6.13.0
+        with:
+          push: false
+          load: true
+          platforms: ${{ env.PLATFORM }}
+          tags: ohttp-relay:testing
+          cache-from: type=registry,ref=${{ env.GHCR_REPO }}:latest
+      - 
+        name: Test-run image
+        run: |
+          docker run --rm -e GATEWAY_ORIGIN=https://payjo.in ohttp-relay:testing &
+          PID=$!
+          sleep 30
+          kill -SIGINT $PID # this will return a non-zero exit code if the container dies early on

--- a/.github/workflows/update-image-on-push.yml
+++ b/.github/workflows/update-image-on-push.yml
@@ -1,0 +1,128 @@
+name: "Update image when Dockerfile is changed"
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'Dockerfile'
+  workflow_dispatch:
+
+env:
+  GHCR_REPO: ghcr.io/${{ github.repository_owner }}/ohttp-relay
+
+jobs:
+  build:
+    name: "Build container for multiple architectures and push by digest"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Prepare platform matrix for arm64
+        if: runner.arch == 'ARM64'
+        run: |
+          echo "PLATFORM=linux/arm64" >> $GITHUB_ENV
+          echo "DIGEST_NAME=arm64" >> $GITHUB_ENV
+      
+      - name: Prepare platform matrix for amd64
+        if: runner.arch == 'X64'
+        run: |
+          echo "PLATFORM=linux/amd64" >> $GITHUB_ENV
+          echo "DIGEST_NAME=amd64" >> $GITHUB_ENV
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_REPO }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.9.0
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Build and and push by digest
+        uses: docker/build-push-action@v6.13.0
+        id: build
+        with:
+          outputs: type=image,"name=${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
+          platforms: ${{ env.PLATFORM }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.GHCR_REPO }}:latest
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.DIGEST_NAME }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: "Merge digests and push with proper tags"
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.9.0
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get ohttp-relay release tag
+        run: echo OHTTP_TAG="$(awk -F '=' '/BRANCH=/ {print $2}' Dockerfile)" >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_REPO }}
+          tags: |
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ env.OHTTP_TAG }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.GHCR_REPO }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/update-image-on-push.yml
+++ b/.github/workflows/update-image-on-push.yml
@@ -103,9 +103,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Get ohttp-relay release tag
-        run: echo OHTTP_TAG="$(awk -F '=' '/BRANCH=/ {print $2}' Dockerfile)" >> $GITHUB_ENV
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -115,7 +112,6 @@ jobs:
           tags: |
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ env.OHTTP_TAG }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM nixos/nix:2.20.5 AS builder
 # Set ohttp-relay branch or tag to build from
 ARG BRANCH=v0.0.9
 
-# Clone our source and switch to cloned directory
-RUN git clone --branch ${BRANCH} https://github.com/payjoin/ohttp-relay.git /tmp/build
+# Copy our source and setup our working directory
+COPY . /tmp/build
 WORKDIR /tmp/build
 
 # Build our Nix environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Stage 1: Building the binary
 FROM nixos/nix:2.20.5 AS builder
 
-# Set ohttp-relay branch or tag to build from
-ARG BRANCH=v0.0.9
-
 # Copy our source and setup our working directory
 COPY . /tmp/build
 WORKDIR /tmp/build


### PR DESCRIPTION
Feel free to take or leave anything you like here, but wanted to push upstream some minor optimizations to the Dockerfile along with an easy way to get automatic Docker image builds via Github Actions, for both amd64 and arm64.

The main part you may not want is pinning Docker images to releases/tags as I've done here, if not I'm happy to modify the PR to remove that aspect, but I personally like that for two reasons:

1. It ensures that a bad push to master doesn't publish broken images automatically
2. It adds a proper Docker tag that can be used, i.e. this will automatically tag the images with the short-sha, `latest`, and `v0.0.9`