### PR TITLE
Use HeaderValue::from_static instead of a Lazy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ hyper = { version = "1", features = ["http1", "server"] }
 hyper-rustls = { version = "0.26", features = ["webpki-roots"] }
 hyper-tungstenite = { version = "0.13", optional = true }
 hyper-util = { version = "0.1", features = ["client-legacy"] }
-once_cell = "1"
 rustls = { version = "0.22", optional = true }
 tokio = { version = "1", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 tokio-tungstenite = { version = "0.21", optional = true }
@@ -38,6 +37,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.1.1" }
+once_cell = "1"
 rcgen = "0.12"
 tempfile = "3"
 tokio = { version = "1", features = ["process"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ use hyper::{Method, Request, Response};
 use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::{TokioExecutor, TokioIo};
-use once_cell::sync::Lazy;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, UnixListener};
 use tokio_util::net::Listener;
@@ -30,10 +29,8 @@ use crate::error::{BoxError, Error};
 pub mod bootstrap;
 
 pub const DEFAULT_PORT: u16 = 3000;
-pub static OHTTP_RELAY_HOST: Lazy<HeaderValue> =
-    Lazy::new(|| HeaderValue::from_str("0.0.0.0").expect("Invalid HeaderValue"));
-pub static EXPECTED_MEDIA_TYPE: Lazy<HeaderValue> =
-    Lazy::new(|| HeaderValue::from_str("message/ohttp-req").expect("Invalid HeaderValue"));
+pub const OHTTP_RELAY_HOST: HeaderValue = HeaderValue::from_static("0.0.0.0");
+pub const EXPECTED_MEDIA_TYPE: HeaderValue = HeaderValue::from_static("message/ohttp-req");
 
 #[instrument]
 pub async fn listen_tcp(


### PR DESCRIPTION
This does not remove the `once_cell` dependency since it's still used in tests, but does relegate it to a dev dependency.

With the gateway probing, I think `GatewayUri` might be able to have a `const fn from_static`, addressing the last remaining `Lazy`, but I haven't tried yet so I'm not sure if that'll actually work. That said, if removing the dep is desirable then the test can just be modified.