### PR TITLE
Don't cargo update in MSRV CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Fixes for MSRV
         if: matrix.rust == '1.63.0'
         run: |
-          cargo update
           cargo update -p regex --precise 1.9.6
           cargo update -p time@0.3.39 --precise 0.3.20
           cargo update -p tokio --precise 1.38.1


### PR DESCRIPTION
Since not all dependencies have precise semvers constraints, a blanket cargo update can break MSRV.

This means that the repository can bitrot, with CI jobs failing in ways not related to changes to the codebase.

This is a workaround, see also #43 for description of the proper way to fix this.